### PR TITLE
Release/0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ JVM-based (i.e. Paparazzi, Roborazzi) as well as Instrumentation-based (i.e. Sho
 ComposablePreviewScanner also works with:
 - `@PreviewParameters`
 - Multi-Previews, including  `@PreviewScreenSizes`, `@PreviewFontScales`, `@PreviewLightDark`, and `@PreviewDynamicColors`.
+- private `@Previews` (from version 0.1.3 on)
 
 but does not work with
-- private `@Previews`. They must be either public or internal.
 - `@Previews` that are not located in the "main" source
 - `@Previews` inside classes, as reported in [this issue](https://github.com/sergio-sastre/ComposablePreviewScanner/issues/4)
 
@@ -83,6 +83,7 @@ AndroidComposablePreviewScanner()
         ScreenshotConfig::class.java,
         ScreenshotConfig2::class.java
     )
+    .includePrivatePreviews() // Otherwise they are ignored
     .filterPreviews { 
         // filter by any previewInfo: name, group, apiLevel, locale, uiMode, fontScale...
         previewInfo ->  previewInfo.apiLevel == 30 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "android"
-            version = "0.1.2"
+            version = "0.1.3"
         }
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -63,7 +63,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "core"
-            version = "0.1.2"
+            version = "0.1.3"
         }
     }
 }

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/ComposablePreviewScanner.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/ComposablePreviewScanner.kt
@@ -15,6 +15,7 @@ abstract class ComposablePreviewScanner<T>(
 ) {
 
     private var updatedClassGraph = ClassGraph()
+        .ignoreMethodVisibility()
         .enableClassInfo()
         .enableMethodInfo()
         .enableAnnotationInfo()

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/dump/ScanResultDumper.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/dump/ScanResultDumper.kt
@@ -12,6 +12,7 @@ import java.util.Locale
  */
 class ScanResultDumper {
     private var updatedClassGraph = ClassGraph()
+        .ignoreMethodVisibility()
         .enableClassInfo()
         .enableMethodInfo()
         .enableAnnotationInfo()

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/filter/ScanResultFilter.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/filter/ScanResultFilter.kt
@@ -13,18 +13,47 @@ class ScanResultFilter<T> internal constructor(
 ) {
     private var scanResultFilterState = ScanResultFilterState<T>()
 
+    /**
+     * Excludes previews which use any of the given annotations, so they will not be returned
+     */
     fun excludeIfAnnotatedWithAnyOf(vararg annotations: Class<out Annotation>) = apply {
         scanResultFilterState = scanResultFilterState.copy(
             excludedAnnotations = annotations.toList()
         )
     }
 
+    /**
+     * Relevant info for screenshot testing a given preview
+     * (e.g. tolerance, renderingMode, etc.) can be passed via annotations. For instance
+     *
+     * @ScreenshotTestConfig(tolerance = 0.85f)
+     * @Preview
+     * fun MyComposable() { ... }
+     *
+     * By default, that info is ignored.
+     *
+     * This makes that info in the annotations accessible in your screenshot tests
+     * via (following the previous example) ComposablePreview.getAnnotation<ScreenshotTestConfig>()
+     */
     fun includeAnnotationInfoForAllOf(vararg annotations: Class<out Annotation>) = apply {
         scanResultFilterState = scanResultFilterState.copy(
             namesOfIncludeAnnotationsInfo = annotations.map { it.name }.toSet()
         )
     }
 
+    /**
+     * By default, private previews are filtered out. You can use this option to also return them
+     */
+    fun includePrivatePreviews() = apply {
+        scanResultFilterState = scanResultFilterState.copy(
+            includesPrivatePreviews = true
+        )
+    }
+
+    /**
+     * Filter only previews whose info meets the predicate, for instance
+     * apiLevel >= 30 or group == "IncludeForScreenshotTests"
+     */
     fun filterPreviews(predicate: (T) -> Boolean) = apply {
         scanResultFilterState = scanResultFilterState.copy(
             meetsPreviewCriteria = predicate,

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/filter/ScanResultFilterState.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/filter/ScanResultFilterState.kt
@@ -4,4 +4,5 @@ data class ScanResultFilterState<T>(
     val excludedAnnotations: List<Class<out Annotation>> = emptyList(),
     val namesOfIncludeAnnotationsInfo: Set<String> = emptySet(),
     val meetsPreviewCriteria: (T) -> Boolean = { true },
+    val includesPrivatePreviews: Boolean = false,
 )

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 23
+        minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -61,7 +61,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "jvm"
-            version = "0.1.2"
+            version = "0.1.3"
         }
     }
 }

--- a/tests/src/main/java/sergio/sastre/composable/preview/scanner/privatepreviews/Composables.kt
+++ b/tests/src/main/java/sergio/sastre/composable/preview/scanner/privatepreviews/Composables.kt
@@ -3,14 +3,25 @@ package sergio.sastre.composable.preview.scanner.privatepreviews
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import sergio.sastre.composable.preview.scanner.StringProvider
+
 
 @Composable
-fun Example(){
-    Text("Example")
+fun Example(name: String) {
+    Text(name)
 }
 
 @Preview
 @Composable
-private fun ExamplePreview(){
-    Example()
+private fun ExamplePreview() {
+    Example("Example")
+}
+
+@Preview
+@Composable
+private fun ExampleParameterizedPreview(
+    @PreviewParameter(provider = StringProvider::class) name: String
+) {
+    Example(name)
 }

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/AndroidComposablePreviewScannerTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/AndroidComposablePreviewScannerTest.kt
@@ -173,7 +173,18 @@ class AndroidComposablePreviewScannerTest {
     }
 
     @Test
-    fun `GIVEN private previews THEN those previews are excluded`() {
+    fun `GIVEN private previews WHEN including them, THEN those previews are included`() {
+        val privatePreviews =
+            AndroidComposablePreviewScanner()
+                .scanPackageTrees("sergio.sastre.composable.preview.scanner.privatepreviews")
+                .includePrivatePreviews()
+                .getPreviews()
+
+        assert(privatePreviews.isNotEmpty())
+    }
+
+    @Test
+    fun `GIVEN private previews WHEN not implicitely including them THEN those previews are excluded`() {
         val privatePreviews =
             AndroidComposablePreviewScanner()
                 .scanPackageTrees("sergio.sastre.composable.preview.scanner.privatepreviews")


### PR DESCRIPTION
This release resolves issues #14 & #15:
- Add support for **_private @ Previews_** via `.includePrivatePreviews()` 
- Decrease required minSdk from 23 to 21, since many Android TVs still run on SDK 21