### PR TITLE
Release/0.6.1

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -67,7 +67,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "android"
-            version = "0.6.0"
+            version = "0.6.1"
         }
     }
 }

--- a/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/DevicePreviewInfoParser.kt
+++ b/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/DevicePreviewInfoParser.kt
@@ -124,6 +124,7 @@ private object GetCustomDevice {
         val cutoutValue = cutout?.let { Cutout.entries.find { it.value == cutout } } ?: NONE
 
         return Device(
+            identifier = null,
             dimensions = dimensions,
             shape = roundShapeValue,
             densityDpi = dpiValue,

--- a/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/domain/Device.kt
+++ b/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/domain/Device.kt
@@ -6,7 +6,7 @@ import kotlin.math.ceil
 import kotlin.math.floor
 
 data class Device(
-    val identifier: Identifier? = null,
+    val identifier: Identifier?,
     val dimensions: Dimensions,
     val densityDpi: Int,
     val orientation: Orientation,

--- a/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/domain/Identifier.kt
+++ b/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/domain/Identifier.kt
@@ -11,9 +11,12 @@ data class Identifier(val id: String? = null, val name: String? = null) {
         val NEXUS_5X = Identifier(id = "Nexus 5X", name = "Nexus 5X")
         val NEXUS_6 = Identifier(id = "Nexus 6", name = "Nexus 6")
         val NEXUS_6P = Identifier(id = "Nexus 6P", name = "Nexus 6P")
-        val NEXUS_7 = Identifier(id = "Nexus 7", name = "Nexus 7")
-        val NEXUS_7_2012 = Identifier(id = null, name = "Nexus 7 (2012)")
-        val NEXUS_7_2013 = Identifier(id = "Nexus 7 2013", name = null)
+
+        // @Preview parameter device "id:Nexus 7" and "name:Nexus 7" point indeed to different devices
+        // This matching problem is likely an error in Android Studio, but we want to keep it consistent with it
+        val NEXUS_7_2012 = Identifier(id = "Nexus 7", name = "Nexus 7 (2012)")
+        val NEXUS_7_2013 = Identifier(id = "Nexus 7 2013", name = "Nexus 7")
+
         val NEXUS_9 = Identifier(id = "Nexus 9", name = "Nexus 9")
         val NEXUS_10 = Identifier(id = "Nexus 10", name = "Nexus 10")
         val PIXEL = Identifier(id = "pixel", name = "Pixel")
@@ -42,14 +45,18 @@ data class Identifier(val id: String? = null, val name: String? = null) {
         val PIXEL_9_PRO = Identifier(id = "pixel_9_pro", name = "Pixel 9 Pro")
         val PIXEL_9_PRO_XL = Identifier(id = "pixel_9_pro_xl", name = "Pixel 9 Pro XL")
         val PIXEL_9_PRO_FOLD = Identifier(id = "pixel_9_pro_fold", name = "Pixel 9 Pro Fold")
+        val PIXEL_TABLET = Identifier(id = "pixel_tablet", name = "Pixel Tablet")
         val PIXEL_C = Identifier(id = "pixel_c", name = "Pixel C")
         val PIXEL_FOLD = Identifier(id = "pixel_fold", name = "Pixel Fold")
 
         // Wear
         val WEAR_OS_SQUARE = Identifier(id = "wearos_square", name = "Wear OS Square")
-        val WEAR_OS_RECTANGULAR = Identifier(id = "wearos_rectangular", name = "Wear OS Rectangular")
-        val WEAR_OS_SMALL_ROUND = Identifier(id = "wearos_small_round", name = "Wear OS Small Round")
-        val WEAR_OS_LARGE_ROUND = Identifier(id = "wearos_large_round", name = "Wear OS Large Round")
+        val WEAR_OS_RECTANGULAR =
+            Identifier(id = "wearos_rectangular", name = "Wear OS Rectangular")
+        val WEAR_OS_SMALL_ROUND =
+            Identifier(id = "wearos_small_round", name = "Wear OS Small Round")
+        val WEAR_OS_LARGE_ROUND =
+            Identifier(id = "wearos_large_round", name = "Wear OS Large Round")
 
         // Desktop
         val SMALL_DESKTOP = Identifier(id = "desktop_small", name = "Small Desktop")
@@ -57,15 +64,30 @@ data class Identifier(val id: String? = null, val name: String? = null) {
         val LARGE_DESKTOP = Identifier(id = "desktop_large", name = "Large Desktop")
 
         // Automotive
-        val AUTOMOTIVE_ULTRAWIDE = Identifier(id ="automotive_ultrawide", name = "Automotive Ultrawide")
-        val AUTOMOTIVE_PORTRAIT = Identifier(id ="automotive_portrait", name = "Automotive Portrait")
-        val AUTOMOTIVE_LARGE_PORTRAIT = Identifier(id ="automotive_large_portrait", name = "Automotive Large Portrait")
-        val AUTOMOTIVE_DISTANT_DISPLAY = Identifier(id ="automotive_distant_display", name = "Automotive Distant Display")
-        val AUTOMOTIVE_DISTANT_DISPLAY_WITH_GOOGLE_PLAY = Identifier(id ="automotive_distant_display_with_play", name = "Automotive Distant Display with Google Play")
-        val AUTOMOTIVE_1024DP_LANDSCAPE = Identifier(id ="automotive_1024p_landscape", name = "Automotive (1024p landscape)")
-        val AUTOMOTIVE_1080DP_LANDSCAPE = Identifier(id ="automotive_1080p_landscape", name = "Automotive (1080p landscape)")
-        val AUTOMOTIVE_1408DP_LANDSCAPE = Identifier(id ="automotive_1408p_landscape_with_google_apis", name = "Automotive (1408p landscape)")
-        val AUTOMOTIVE_1408DP_LANDSCAPE_WITH_GOOGLE_PLAY = Identifier(id ="automotive_1408p_landscape_with_play", name = "Automotive (1408p landscape) with Google Play")
+        val AUTOMOTIVE_ULTRAWIDE =
+            Identifier(id = "automotive_ultrawide", name = "Automotive Ultrawide")
+        val AUTOMOTIVE_PORTRAIT =
+            Identifier(id = "automotive_portrait", name = "Automotive Portrait")
+        val AUTOMOTIVE_LARGE_PORTRAIT =
+            Identifier(id = "automotive_large_portrait", name = "Automotive Large Portrait")
+        val AUTOMOTIVE_DISTANT_DISPLAY =
+            Identifier(id = "automotive_distant_display", name = "Automotive Distant Display")
+        val AUTOMOTIVE_DISTANT_DISPLAY_WITH_GOOGLE_PLAY = Identifier(
+            id = "automotive_distant_display_with_play",
+            name = "Automotive Distant Display with Google Play"
+        )
+        val AUTOMOTIVE_1024DP_LANDSCAPE =
+            Identifier(id = "automotive_1024p_landscape", name = "Automotive (1024p landscape)")
+        val AUTOMOTIVE_1080DP_LANDSCAPE =
+            Identifier(id = "automotive_1080p_landscape", name = "Automotive (1080p landscape)")
+        val AUTOMOTIVE_1408DP_LANDSCAPE = Identifier(
+            id = "automotive_1408p_landscape_with_google_apis",
+            name = "Automotive (1408p landscape)"
+        )
+        val AUTOMOTIVE_1408DP_LANDSCAPE_WITH_GOOGLE_PLAY = Identifier(
+            id = "automotive_1408p_landscape_with_play",
+            name = "Automotive (1408p landscape) with Google Play"
+        )
 
         // Television
         val TV_720p = Identifier(id = "tv_720p", name = "Television (720p)")

--- a/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/types/Default.kt
+++ b/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/types/Default.kt
@@ -9,6 +9,7 @@ import sergio.sastre.composable.preview.scanner.android.device.domain.Unit.PX
 
 val DEFAULT: Device
     get() = Device(
+        identifier = null,
         dimensions = Dimensions(
             width = 1080f,
             height = 2340f,

--- a/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/types/Tablet.kt
+++ b/android/src/main/java/sergio/sastre/composable/preview/scanner/android/device/types/Tablet.kt
@@ -16,6 +16,7 @@ enum class Tablet(
 
     PIXEL_TABLET(
         Device(
+            identifier = Identifier.PIXEL_TABLET,
             dimensions = Dimensions(
                 width = 2560f,
                 height = 1600f,
@@ -55,22 +56,6 @@ enum class Tablet(
             ),
             densityDpi = 420,
             orientation = LANDSCAPE,
-            shape = NOTROUND,
-            chinSize = 0,
-            type = TABLET
-        )
-    ),
-
-    NEXUS_7(
-        Device(
-            identifier = Identifier.NEXUS_7,
-            dimensions = Dimensions(
-                width = 800f,
-                height = 1280f,
-                unit = PX
-            ),
-            densityDpi = 213,
-            orientation = PORTRAIT,
             shape = NOTROUND,
             chinSize = 0,
             type = TABLET

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,7 +24,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "core"
-            version = "0.6.0"
+            version = "0.6.1"
         }
     }
 }

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "jvm"
-            version = "0.6.0"
+            version = "0.6.1"
         }
     }
 }

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/DevicePreviewInfoParserTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/DevicePreviewInfoParserTest.kt
@@ -3,10 +3,11 @@ package sergio.sastre.composable.preview.scanner.tests.api.main
 import app.cash.paparazzi.DeviceConfig
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.google.testing.junit.testparameterinjector.TestParameter
-import org.junit.runner.RunWith
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import sergio.sastre.composable.preview.scanner.android.device.DevicePreviewInfoParser
 import sergio.sastre.composable.preview.scanner.android.device.domain.Cutout
 import sergio.sastre.composable.preview.scanner.android.device.domain.Dimensions
 import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation
@@ -16,7 +17,6 @@ import sergio.sastre.composable.preview.scanner.android.device.domain.Orientatio
 import sergio.sastre.composable.preview.scanner.android.device.domain.Shape
 import sergio.sastre.composable.preview.scanner.android.device.domain.Shape.NOTROUND
 import sergio.sastre.composable.preview.scanner.android.device.domain.Shape.ROUND
-import sergio.sastre.composable.preview.scanner.android.device.DevicePreviewInfoParser
 import sergio.sastre.composable.preview.scanner.android.device.domain.Type
 import sergio.sastre.composable.preview.scanner.android.device.domain.Type.DESKTOP
 import sergio.sastre.composable.preview.scanner.android.device.domain.Type.FOLDABLE
@@ -44,6 +44,7 @@ class DevicePreviewInfoParserTest {
         DimensionsInPxExplicit("spec:height=100px,width=200px", Dimensions(100f, 200f, PX)),
         FloatDimensionsInDp("spec:height=100.5dp,width=200.1dp", Dimensions(100.5f, 200.1f, DP)),
     }
+
     @Test
     fun `GIVEN device height, extract its value`(
         @TestParameter customDimensions: CustomDimensions
@@ -69,6 +70,7 @@ class DevicePreviewInfoParserTest {
         NoDpi("spec:height=100dp,width=200dp", 420),
         WithDpi("spec:dpi=320$DIMENS", 320),
     }
+
     @Test
     fun `GIVEN dpi, extract its value`(
         @TestParameter customDpi: CustomDpi
@@ -92,6 +94,7 @@ class DevicePreviewInfoParserTest {
         ShapeNormal("spec:shape=Normal$DIMENS", NOTROUND),
         ShapeRound("spec:shape=Round$DIMENS", ROUND),
     }
+
     @Test
     fun `GIVEN shape, extract its value`(
         @TestParameter customShape: CustomShape
@@ -113,6 +116,7 @@ class DevicePreviewInfoParserTest {
         TypePhone("spec:id=reference_phone$DIMENS", PHONE),
         TypeTablet("spec:id=reference_tablet$DIMENS", TABLET),
     }
+
     @Test
     fun `GIVEN type, extract its value`(
         @TestParameter customType: CustomType
@@ -134,6 +138,7 @@ class DevicePreviewInfoParserTest {
         Portrait("spec:orientation=portrait$DIMENS", PORTRAIT),
         Landscape("spec:orientation=landscape$DIMENS", LANDSCAPE),
     }
+
     @Test
     fun `GIVEN orientation, extract its value`(
         @TestParameter customOrientation: CustomOrientation
@@ -157,6 +162,7 @@ class DevicePreviewInfoParserTest {
         PunchHole("spec:cutout=punch_hole$DIMENS", Cutout.PUNCH_HOLE),
         Tall("spec:cutout=tall$DIMENS", Cutout.TALL),
     }
+
     @Test
     fun `GIVEN cutout, extract its value`(
         @TestParameter customCutout: CustomCutouts
@@ -176,6 +182,7 @@ class DevicePreviewInfoParserTest {
         NoChinSizeDefaults0("spec:height=200dp,width=100dp", 0),
         ChinSize("spec:chinSize=8dp$DIMENS", 8),
     }
+
     @Test
     fun `GIVEN chinSize, extract its value`(
         @TestParameter customChinSize: CustomChinSize
@@ -196,6 +203,7 @@ class DevicePreviewInfoParserTest {
         NavigationGesture("spec:navigation=gesture$DIMENS", Navigation.GESTURE),
         NavigationButtons("spec:navigation=buttons$DIMENS", Navigation.BUTTONS),
     }
+
     @Test
     fun `GIVEN navigation, extract its value`(
         @TestParameter customNavigation: CustomNavigation
@@ -214,11 +222,28 @@ class DevicePreviewInfoParserTest {
         val expectedNavigation: Navigation
     ) {
         JustParent("spec:parent=Nexus One", PORTRAIT, Navigation.GESTURE),
-        ParentAndOrientationReversed("spec:orientation=landscape,parent=Nexus One", LANDSCAPE, Navigation.GESTURE),
-        ParentAndOrientation("spec:parent=Nexus One,orientation=landscape", LANDSCAPE, Navigation.GESTURE),
-        ParentAndNavigation("spec:parent=Nexus One,navigation=buttons", PORTRAIT, Navigation.BUTTONS),
-        ParentAndOrientationAndNavigation("spec:parent=Nexus One,orientation = landscape,navigation=buttons", LANDSCAPE, Navigation.BUTTONS),
+        ParentAndOrientationReversed(
+            "spec:orientation=landscape,parent=Nexus One",
+            LANDSCAPE,
+            Navigation.GESTURE
+        ),
+        ParentAndOrientation(
+            "spec:parent=Nexus One,orientation=landscape",
+            LANDSCAPE,
+            Navigation.GESTURE
+        ),
+        ParentAndNavigation(
+            "spec:parent=Nexus One,navigation=buttons",
+            PORTRAIT,
+            Navigation.BUTTONS
+        ),
+        ParentAndOrientationAndNavigation(
+            "spec:parent=Nexus One,orientation = landscape,navigation=buttons",
+            LANDSCAPE,
+            Navigation.BUTTONS
+        ),
     }
+
     @Test
     fun `GIVEN spec parent, has expected device with given orientation and navigation`(
         @TestParameter deviceParent: DeviceParent
@@ -236,8 +261,11 @@ class DevicePreviewInfoParserTest {
         val deviceId: String,
         val roborazziDeviceQualifier: String,
     ) {
+        // Android previews have a very weird matching for this device; id:Nexus 7 and name:Nexus 7 map to different devices
+        Nexus7Name("name:Nexus 7", RobolectricDeviceQualifiers.Nexus7),
+        Nexus7Id("id:Nexus 7 2013", RobolectricDeviceQualifiers.Nexus7),
+
         NexusOne("id:Nexus One", RobolectricDeviceQualifiers.NexusOne),
-        Nexus7("id:Nexus 7", RobolectricDeviceQualifiers.Nexus7),
         Nexus9("id:Nexus 9", RobolectricDeviceQualifiers.Nexus9),
         PixelC("id:pixel_c", RobolectricDeviceQualifiers.PixelC),
         PixelXL("id:pixel_xl", RobolectricDeviceQualifiers.PixelXL),
@@ -259,8 +287,12 @@ class DevicePreviewInfoParserTest {
         SmallDesktop("id:desktop_small", RobolectricDeviceQualifiers.SmallDesktop),
         MediumDesktop("id:desktop_medium", RobolectricDeviceQualifiers.MediumDesktop),
         LargeDesktop("id:desktop_large", RobolectricDeviceQualifiers.LargeDesktop),
-        Automotive1024pLandscape("id:automotive_1024p_landscape", RobolectricDeviceQualifiers.Automotive1024plandscape)
+        Automotive1024pLandscape(
+            "id:automotive_1024p_landscape",
+            RobolectricDeviceQualifiers.Automotive1024plandscape
+        )
     }
+
     @Test
     fun `GIVEN device id, WHEN converted to Dp, has expected Roborazzi height and width with error margin up to 1f`(
         @TestParameter deviceMapping: DeviceIdMapping
@@ -269,16 +301,22 @@ class DevicePreviewInfoParserTest {
         val expectedDeviceInDp = expectedDevice.inDp()
 
         assertEquals(
-            expectedDeviceInDp.dimensions.height, deviceMapping.roborazziDeviceQualifier.extractHeight(), 1f
+            expectedDeviceInDp.dimensions.height,
+            deviceMapping.roborazziDeviceQualifier.extractHeight(),
+            1f
         )
         assertEquals(
-            expectedDeviceInDp.dimensions.width, deviceMapping.roborazziDeviceQualifier.extractWidth(), 1f
+            expectedDeviceInDp.dimensions.width,
+            deviceMapping.roborazziDeviceQualifier.extractWidth(),
+            1f
         )
         assertEquals(
-            expectedDevice.screenRatio.name.lowercase(), deviceMapping.roborazziDeviceQualifier.extractScreenRatio()
+            expectedDevice.screenRatio.name.lowercase(),
+            deviceMapping.roborazziDeviceQualifier.extractScreenRatio()
         )
         assertEquals(
-            expectedDevice.screenSize.name.lowercase(), deviceMapping.roborazziDeviceQualifier.extractScreenSize()
+            expectedDevice.screenSize.name.lowercase(),
+            deviceMapping.roborazziDeviceQualifier.extractScreenSize()
         )
     }
 
@@ -305,6 +343,7 @@ class DevicePreviewInfoParserTest {
         WearOSSmallRound("id:wearos_small_round", DeviceConfig.WEAR_OS_SMALL_ROUND),
         WearOSSquare("id:wearos_square", DeviceConfig.WEAR_OS_SQUARE),
     }
+
     @Test
     fun `GIVEN device id, WHEN converted to Dp, has expected Paparazzi screen ratio`(
         @TestParameter deviceMapping: DeviceIdPaparazziMapping
@@ -312,11 +351,13 @@ class DevicePreviewInfoParserTest {
         val expectedDevice = DevicePreviewInfoParser.parse(deviceMapping.deviceId)!!
 
         assertEquals(
-            expectedDevice.screenRatio.name.lowercase(), deviceMapping.expectedDeviceConfig.ratio.name.lowercase()
+            expectedDevice.screenRatio.name.lowercase(),
+            deviceMapping.expectedDeviceConfig.ratio.name.lowercase()
         )
 
         assertEquals(
-            expectedDevice.screenSize.name.lowercase(), deviceMapping.expectedDeviceConfig.size.name.lowercase()
+            expectedDevice.screenSize.name.lowercase(),
+            deviceMapping.expectedDeviceConfig.size.name.lowercase()
         )
     }
 
@@ -370,13 +411,20 @@ class DevicePreviewInfoParserTest {
         WearOSLargeRound("name:Wear OS Large Round", RobolectricDeviceQualifiers.WearOSLargeRound),
         WearOSSmallRound("name:Wear OS Small Round", RobolectricDeviceQualifiers.WearOSSmallRound),
         WearOSSquare("name:Wear OS Square", RobolectricDeviceQualifiers.WearOSSquare),
-        WearOSRectangular("name:Wear OS Rectangular", RobolectricDeviceQualifiers.WearOSRectangular),
+        WearOSRectangular(
+            "name:Wear OS Rectangular",
+            RobolectricDeviceQualifiers.WearOSRectangular
+        ),
 
         SmallDesktop("name:Small Desktop", RobolectricDeviceQualifiers.SmallDesktop),
         MediumDesktop("name:Medium Desktop", RobolectricDeviceQualifiers.MediumDesktop),
         LargeDesktop("name:Large Desktop", RobolectricDeviceQualifiers.LargeDesktop),
-        Automotive1024pLandscape("name:Automotive (1024p landscape)", RobolectricDeviceQualifiers.Automotive1024plandscape)
+        Automotive1024pLandscape(
+            "name:Automotive (1024p landscape)",
+            RobolectricDeviceQualifiers.Automotive1024plandscape
+        )
     }
+
     @Test
     fun `GIVEN device name, WHEN converted to Dp, has expected Roborazzi height and width with error margin up to 1f`(
         @TestParameter deviceMapping: DeviceNameMapping
@@ -385,17 +433,22 @@ class DevicePreviewInfoParserTest {
             DevicePreviewInfoParser.parse(deviceMapping.deviceName)!!.inDp()
 
         assertEquals(
-            expectedDeviceInDp.dimensions.height, deviceMapping.roborazziDeviceQualifier.extractHeight(), 1f
+            expectedDeviceInDp.dimensions.height,
+            deviceMapping.roborazziDeviceQualifier.extractHeight(),
+            1f
         )
         assertEquals(
-            expectedDeviceInDp.dimensions.width, deviceMapping.roborazziDeviceQualifier.extractWidth(), 1f
+            expectedDeviceInDp.dimensions.width,
+            deviceMapping.roborazziDeviceQualifier.extractWidth(),
+            1f
         )
     }
 
-    enum class XR_DEVICE(val identifier:String) {
+    enum class XR_DEVICE(val identifier: String) {
         ID("id:xr_device"),
         NAME("name:XR Device")
     }
+
     @Test
     fun `GIVEN XR Device, has expected dimensions, density and orientation`(
         @TestParameter xrDevice: XR_DEVICE


### PR DESCRIPTION
# What's new
- Device info preview improvements:
1. `PIXEL TABLET` parsing was missing (no identifier was provided)
2. `NEXUS 7` `id:` and `name:` matching was not fully correct. This comes from the fact that Nexus 7 (2012) and Nexus 7 (2013) devices are supported in Android, what creates ambiguity. 

# Caution
If you were using `Nexus 7` in your `@Preview`s, you might encounter some differences in the generated screenshots. However, the current one should be more accurate to what you see in your `@Preview`s in Android Studio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the Pixel Tablet device identifier.
- **Bug Fixes**
	- Corrected Nexus 7 device identifiers to address inconsistencies in device matching.
- **Refactor**
	- Updated device identifier handling to require explicit assignment, improving clarity.
	- Removed the Nexus 7 device entry from the tablet device list.
- **Chores**
	- Bumped version numbers for Android, core, and JVM libraries to 0.6.1.
- **Style**
	- Improved code and test formatting for better readability.
- **Documentation**
	- Added clarifying comments regarding Nexus 7 device matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->