### PR TITLE
Add support to easily use Classpath for ScreenshotTest Source Set in legacy AGP Versions

### DIFF
--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/config/classpath/Classpath.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/config/classpath/Classpath.kt
@@ -12,7 +12,6 @@ data class Classpath(
     val packagePath: String,
     val rootDir: String = "${System.getProperty("user.dir")}/build"
 ) {
-
     /**
      * Creates a Classpath for the given SourceSet and variant
      *
@@ -30,7 +29,24 @@ data class Classpath(
         }
     )
 
+    /**
+     * Creates a Classpath for the given SourceSet and variant
+     *
+     * @param legacySourceSetClasspath SourceSet used with an older AGP version, in which the packagePath differs from the one used in the last AGP versions
+     * @param variantName The variant of the sourceSet, usually "debug" or "release" but could be a custom one e.g. custom flavours
+     */
+    constructor(
+        legacySourceSetClasspath: LegacySourceSetClasspath,
+        variantName: String = "debug"
+    ) : this(
+        packagePath = when (legacySourceSetClasspath) {
+            LegacySourceSetClasspath.SCREENSHOT_TEST_PRE_AGP_8_7_0 ->
+                "intermediates/kotlinc/compile${capitalize(variantName)}ScreenshotTestKotlin/classes"
+        }
+    )
+
     companion object {
+
         private fun getMainSourceSetPath(variantName: String): String =
             "tmp/kotlin-classes/$variantName"
 
@@ -39,14 +55,12 @@ data class Classpath(
 
         private fun getScreenshotTestSourceSetPath(variantName: String): String {
             val capitalizedVariantName = capitalize(variantName)
-            // Path for AGP 8.7.0 and above.
-            // Pre AGP 8.7.0 -> return "intermediates/kotlinc/${variantName}ScreenshotTest/compile${capitalizedVariantName}ScreenshotTestKotlin/classes"
             return "intermediates/built_in_kotlinc/${variantName}ScreenshotTest/compile${capitalizedVariantName}ScreenshotTestKotlin/classes"
         }
 
         private fun capitalize(variantName: String): String =
             variantName.replaceFirstChar {
-                if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
             }
     }
 }

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/config/classpath/LegacySourceSetClasspath.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/config/classpath/LegacySourceSetClasspath.kt
@@ -1,0 +1,5 @@
+package sergio.sastre.composable.preview.scanner.core.scanner.config.classpath
+
+enum class LegacySourceSetClasspath {
+    SCREENSHOT_TEST_PRE_AGP_8_7_0
+}

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/exceptions/CompiledClassesNotFound.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/exceptions/CompiledClassesNotFound.kt
@@ -15,12 +15,18 @@ private fun buildErrorMessage(classpath: Classpath): String {
         lowercasePackagePath.contains("screenshottest") -> "ScreenshotTest"
         else -> "<SourceSet>"
     }
+    val agpWarning = when {
+        lowercasePackagePath.contains("screenshottest") -> "\nWARNING: If using AGP 8.6.x or prior, configure ComposablePreviewScanner " +
+                "with .setTargetSourceSet(LegacySourceSetClasspath.SCREENSHOT_TEST)"
+        else -> ""
+    }
     return "No compiled classes under $path. Generate them by executing the corresponding 'compile' task:\n" +
             "> ./gradlew :mymodule:compile<Variant>${sourceSet}Kotlin, where Variant is usually Debug or Release\n" +
             ">\n" +
             "> Alternatively, you can configure gradle to always run that command before running JVM-screenshot tests like this:\n" +
             "> tasks.withType<Test> {\n" +
             ">   dependsOn(\"compile<Variant>${sourceSet}Kotlin\")\n" +
-            ">}"
+            ">}" +
+            agpWarning
 
 }

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/AndroidComposablePreviewScannerSourceSetMissingTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/AndroidComposablePreviewScannerSourceSetMissingTest.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 class AndroidComposablePreviewScannerSourceSetMissingTest {
     @Test
-    fun `GIVEN 'screenshotTest' compiled classes do not exist WHEN target Source Set THEN throw CompiledClassesNotFound error`() {
+    fun `GIVEN 'screenshotTest' compiled classes do not exist WHEN target Source Set THEN throw CompiledClassesNotFound error with AGP warning`() {
         val classpath = Classpath(SourceSet.SCREENSHOT_TEST)
         val file = File(classpath.rootDir, classpath.packagePath)
         Assume.assumeFalse(file.exists())
@@ -30,7 +30,8 @@ class AndroidComposablePreviewScannerSourceSetMissingTest {
                     "> Alternatively, you can configure gradle to always run that command before running JVM-screenshot tests like this:\n" +
                     "> tasks.withType<Test> {\n" +
                     ">   dependsOn(\"compile<Variant>ScreenshotTestKotlin\")\n" +
-                    ">}",
+                    ">}\n" +
+                    "WARNING: If using AGP 8.6.x or prior, configure ComposablePreviewScanner with .setTargetSourceSet(LegacySourceSetClasspath.SCREENSHOT_TEST)",
             exception.message
         )
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy Android Gradle Plugin (AGP) versions when configuring source sets for screenshot tests.
  * Introduced a new option to specify legacy source sets for improved compatibility.

* **Bug Fixes**
  * Enhanced error messages to provide clearer guidance for users on AGP 8.6.x or earlier, including specific configuration warnings.

* **Tests**
  * Updated tests to verify the presence of new AGP-related warnings in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->