### PR TITLE
Update Paparazzi examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,9 +357,13 @@ object DeviceConfigBuilder {
 }
 
 object PaparazziPreviewRule {
+    const val UNDEFINED_API_LEVEL = -1
+    const val MAX_API_LEVEL = 36
+    
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Paparazzi {
-       val previewApiLevel = when(previewInfo.apiLevel == -1) {
-          true -> 36
+       val previewInfo = preview.previewInfo
+       val previewApiLevel = when(previewInfo.apiLevel == UNDEFINED_API_LEVEL) {
+          true -> MAX_API_LEVEL
           false -> previewInfo.apiLevel
        }
        return Paparazzi(

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ object PaparazziPreviewRule {
        }
        return Paparazzi(
             environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
-            deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
+            deviceConfig = DeviceConfigBuilder.build(previewInfo),
             supportsRtl = true,
             showSystemUi = previewInfo.showSystemUi,
             renderingMode = when {

--- a/README.md
+++ b/README.md
@@ -358,8 +358,12 @@ object DeviceConfigBuilder {
 
 object PaparazziPreviewRule {
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Paparazzi {
-        val previewInfo = preview.previewInfo
-        return Paparazzi(
+       val previewApiLevel = when(previewInfo.apiLevel == -1) {
+          true -> 36
+          false -> previewInfo.apiLevel
+       }
+       return Paparazzi(
+            environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
             deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
             supportsRtl = true,
             showSystemUi = previewInfo.showSystemUi,

--- a/paparazzi-plugin-tests/src/main/java/sergio/sastre/composable/preview/scanner/paparazzi/plugin/Composables.kt
+++ b/paparazzi-plugin-tests/src/main/java/sergio/sastre/composable/preview/scanner/paparazzi/plugin/Composables.kt
@@ -1,5 +1,6 @@
 package sergio.sastre.composable.preview.scanner.paparazzi.plugin
 
+import android.os.Build
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Devices.PIXEL_C
@@ -7,8 +8,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 
 @Composable
-fun Example() {
-    Text("Example")
+fun Example(apiLevel: String) {
+    Text(apiLevel)
 }
 
 @Preview(device = "id:pixel")
@@ -19,8 +20,9 @@ fun Example() {
     backgroundColor = 0xFF000080
 )
 @PreviewScreenSizes
+@Preview(apiLevel = 31)
 @Preview
 @Composable
 fun ScreenSizesExamplePreview() {
-    Example()
+    Example("API ${Build.VERSION.SDK_INT}")
 }

--- a/paparazzi-plugin/README.md
+++ b/paparazzi-plugin/README.md
@@ -29,6 +29,7 @@ However, customizing the plugin to fit your needs should be straightforward: sim
     - `showBackground`
     - `backgroundColor`
     - `showSystemUi`
+    - `apiLevel`
 - 🔒 **Private Preview Support**: Option to include private `@Preview`
 
 ## Usage

--- a/paparazzi-plugin/README.md
+++ b/paparazzi-plugin/README.md
@@ -67,8 +67,8 @@ composablePreviewPaparazzi {
 These are necessary, because the generated test file requires imports from them:
 ```gradle
 dependencies {
-  testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.6.1")
-  testImplementation("com.google.testparameterinjector:test-parameter-injector:1.16")
+  testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.7.0")
+  testImplementation("com.google.testparameterinjector:test-parameter-injector:1.19")
   testImplementation("junit:junit:4.13.2")
 }
 ```

--- a/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
+++ b/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
@@ -147,10 +147,13 @@ abstract class GenerateComposablePreviewPaparazziTestsTask : DefaultTask() {
             }
 
             object PaparazziPreviewRule {
+                const val UNDEFINED_API_LEVEL = -1
+                const val MAX_API_LEVEL = 36
+                
                 fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Paparazzi {
                     val previewInfo = preview.previewInfo
-                    val previewApiLevel = when(previewInfo.apiLevel == -1) {
-                        true -> 36
+                    val previewApiLevel = when(previewInfo.apiLevel == UNDEFINED_API_LEVEL) {
+                        true -> MAX_API_LEVEL
                         false -> previewInfo.apiLevel
                     }
                     return Paparazzi(

--- a/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
+++ b/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
@@ -65,6 +65,7 @@ abstract class GenerateComposablePreviewPaparazziTestsTask : DefaultTask() {
             import androidx.compose.runtime.Composable
             import androidx.compose.ui.Modifier
             import androidx.compose.ui.graphics.Color
+            import app.cash.paparazzi.detectEnvironment
             import app.cash.paparazzi.DeviceConfig
             import app.cash.paparazzi.Paparazzi
             import com.android.ide.common.rendering.api.SessionParams
@@ -148,7 +149,12 @@ abstract class GenerateComposablePreviewPaparazziTestsTask : DefaultTask() {
             object PaparazziPreviewRule {
                 fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Paparazzi {
                     val previewInfo = preview.previewInfo
+                    val previewApiLevel = when(previewInfo.apiLevel == -1) {
+                        true -> 36
+                        false -> previewInfo.apiLevel
+                    }
                     return Paparazzi(
+                        environment = detectEnvironment().copy(compileSdkVersion = previewApiLevel),
                         deviceConfig = DeviceConfigBuilder.build(preview.previewInfo),
                         supportsRtl = true,
                         showSystemUi = previewInfo.showSystemUi,


### PR DESCRIPTION
Update Paparazzi examples in README.md and paparazzi-plugin to include apiLevel support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Paparazzi previews now honor @Preview apiLevel, defaulting to API 36 when unspecified by configuring the test environment accordingly.
  - Generated tests automatically include environment setup to match the selected apiLevel.

- Documentation
  - Added apiLevel as a supported @Preview parameter in the README and updated examples/dependency versions.

- Tests
  - Sample composable updated to display the runtime API level and includes an example @Preview(apiLevel = 31).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->