### PR TITLE
Update version to 0.7.1

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -65,7 +65,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "android"
-            version = "0.7.0"
+            version = "0.7.1"
         }
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "common"
-            version = "0.7.0"
+            version = "0.7.1"
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,7 +24,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "core"
-            version = "0.7.0"
+            version = "0.7.1"
         }
     }
 }

--- a/glance/build.gradle.kts
+++ b/glance/build.gradle.kts
@@ -68,7 +68,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "glance"
-            version = "0.7.0"
+            version = "0.7.1"
         }
     }
 }

--- a/jvm/build.gradle.kts
+++ b/jvm/build.gradle.kts
@@ -23,7 +23,7 @@ publishing {
             }
             groupId = "sergio.sastre.composable.preview.scanner"
             artifactId = "jvm"
-            version = "0.7.0"
+            version = "0.7.1"
         }
     }
 }

--- a/paparazzi-plugin/README.md
+++ b/paparazzi-plugin/README.md
@@ -67,7 +67,7 @@ composablePreviewPaparazzi {
 These are necessary, because the generated test file requires imports from them:
 ```gradle
 dependencies {
-  testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.7.0")
+  testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:android:0.7.1")
   testImplementation("com.google.testparameterinjector:test-parameter-injector:1.19")
   testImplementation("junit:junit:4.13.2")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Published patch release 0.7.1 across Android, Common, Core, Glance, and JVM modules to align artifact versions. Coordinates remain unchanged; only the version advanced.
* **Documentation**
  * Updated dependency instructions to reference 0.7.1.

Impact: Consumers can upgrade to 0.7.1 via their build tools for the latest published artifacts. No API or behavioral changes are expected in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->