### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,12 +397,12 @@ object DeviceConfigBuilder {
          density = Density(parsedDevice.densityDpi),
          xdpi = parsedDevice.densityDpi, // not 100% precise
          ydpi = parsedDevice.densityDpi, // not 100% precise
-         fontScale = preview.fontScale,
          size = ScreenSize.valueOf(parsedDevice.screenSize.name),
          ratio = ScreenRatio.valueOf(parsedDevice.screenRatio.name),
          screenRound = ScreenRound.valueOf(parsedDevice.shape.name),
          orientation = ScreenOrientation.valueOf(parsedDevice.orientation.name),
          locale = preview.locale.ifBlank { "en" },
+          fontScale = preview.fontScale,
          nightMode = when (preview.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES) {
             true -> NightMode.NIGHT
             false -> NightMode.NOTNIGHT

--- a/paparazzi-plugin-tests/src/main/java/sergio/sastre/composable/preview/scanner/paparazzi/plugin/Composables.kt
+++ b/paparazzi-plugin-tests/src/main/java/sergio/sastre/composable/preview/scanner/paparazzi/plugin/Composables.kt
@@ -30,6 +30,7 @@ fun Example(apiLevel: String) {
 )
 @PreviewScreenSizes
 @Preview(apiLevel = 31)
+@Preview(fontScale = 1.3f)
 @Preview
 @Composable
 fun ScreenSizesExamplePreview() {

--- a/paparazzi-plugin/README.md
+++ b/paparazzi-plugin/README.md
@@ -22,7 +22,7 @@ However, customizing the plugin to fit your needs should be straightforward: sim
 - 📱 **Configuration**: Proper configuration based on `@Preview` parameters. Supports:
     - `device`
     - `locale`
-    - `fontSize`
+    - `fontScale`
     - `uiMode`
     - `width`
     - `height`

--- a/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
+++ b/paparazzi-plugin/src/main/kotlin/io/github/sergio/sastre/composable/preview/scanner/paparazzi/plugin/GenerateComposablePreviewPaparazziTestsTask.kt
@@ -141,6 +141,7 @@ abstract class GenerateComposablePreviewPaparazziTestsTask : DefaultTask() {
                         screenRound = ScreenRound.valueOf(parsedDevice.shape.name),
                         orientation = ScreenOrientation.valueOf(parsedDevice.orientation.name),
                         locale = preview.locale.ifBlank { "en" },
+                        fontScale = preview.fontScale,
                         nightMode = when (preview.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES) {
                             true -> NightMode.NIGHT
                             false -> NightMode.NOTNIGHT


### PR DESCRIPTION
Added fontScale to deviceConfig example in readme along with file naming conventions example.

At the very least the font scale is a good idea if anyone is using `@PreviewFontScale`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added code example demonstrating an alternative implementation approach for snapshot handling.

* **New Features**
  * Added fontScale property to device configuration, enabling flexible display scaling customization options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->