### PR TITLE
Change compose-multiplatform v1.10.0 preview annotation class

### DIFF
--- a/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonComposablePreviewScanner.kt
+++ b/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonComposablePreviewScanner.kt
@@ -14,7 +14,7 @@ import java.lang.reflect.Method
  * Scans the target package trees for the @Preview s in "common" in a Compose Multiplatform project
  * and returns their Composable, which can be invoked.
  *
- * This is meant to be used for @Composables using the @Preview located in "org.jetbrains.compose.ui.tooling.preview.Preview",
+ * This is meant to be used for @Composables using the @Preview located in "androidx.compose.ui.tooling.preview.Preview",
  * which is used in Compose Multiplatform for common previews.
  *
  * WARNING: Since ComposablePreviewScanner is based on ClassGraph, which is a Jvm-based Class Scanner,
@@ -26,7 +26,7 @@ class CommonComposablePreviewScanner : ComposablePreviewScanner<CommonPreviewInf
     private object CommonComposablePreviewFinder {
         operator fun invoke(): ClasspathPreviewsFinder<CommonPreviewInfo> =
             ClasspathPreviewsFinder(
-                annotationToScanClassName = "org.jetbrains.compose.ui.tooling.preview.Preview",
+                annotationToScanClassName = "androidx.compose.ui.tooling.preview.Preview",
                 previewInfoMapper = CommonComposablePreviewInfoMapper(),
                 previewMapperCreator = CommonPreviewMapperCreator()
             )
@@ -58,7 +58,7 @@ class CommonComposablePreviewScanner : ComposablePreviewScanner<CommonPreviewInf
                 annotationsInfo: AnnotationInfoList?
             ): ComposablePreviewMapper<CommonPreviewInfo> =
                 ComposablePreviewWithPreviewParameterMapper(
-                    previewParameterClassName = "org.jetbrains.compose.ui.tooling.preview.PreviewParameter",
+                    previewParameterClassName = "androidx.compose.ui.tooling.preview.PreviewParameter",
                     previewMethod = previewMethod,
                     previewInfo = previewInfo,
                     annotationsInfo = annotationsInfo


### PR DESCRIPTION
- annotation class for `common`changed to `androidx.compose.ui.toolig.preview.Preview`
this change fix issue where tests did not run before on v1.10.0, not sure about `maven` resolution issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal preview annotation scanning updated to target AndroidX Compose Preview libraries.
  * Documentation text adjusted to reference the AndroidX Preview types.
  * No public API or exported signatures were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->