### PR TITLE
Refactor logging to use StringBuilder for output

### DIFF
--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/logger/PreviewScanningLogger.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanner/logger/PreviewScanningLogger.kt
@@ -74,23 +74,29 @@ internal class PreviewScanningLogger {
 
     fun printFullInfoLog() {
         if (!isLoggingEnabled) return
+        val logBuilder = StringBuilder()
 
-        println("==============================================================")
-        println("Composable Preview Scanner")
-        println("==============================================================")
-        println(scanningSource)
-        classpath?.run {
-            println("Source set (compiled classes path): $rootDir/$packagePath")
+        logBuilder.run {
+            appendLine("==============================================================")
+            appendLine("Composable Preview Scanner")
+            appendLine("==============================================================")
+            appendLine(scanningSource)
         }
-        println()
-        println("@Preview annotation: $annotationName")
-        println("Amount of @Previews found: $previewsAmount")
-        println()
-        println("Time to scan target files: $scanningFilesTime ms")
-        println("Time to find @Previews: $findPreviewsTime ms")
-        println("--------------------------------------------------------------")
-        println("Total time: ${scanningFilesTime + findPreviewsTime} ms")
-        println("==============================================================")
-        println()
+        classpath?.run {
+            logBuilder.appendLine("Source set (compiled classes path): $rootDir/$packagePath")
+        }
+        logBuilder.run {
+            appendLine()
+            appendLine("@Preview annotation: $annotationName")
+            appendLine("Amount of @Previews found: $previewsAmount")
+            appendLine()
+            appendLine("Time to scan target files: $scanningFilesTime ms")
+            appendLine("Time to find @Previews: $findPreviewsTime ms")
+            appendLine("--------------------------------------------------------------")
+            appendLine("Total time: ${scanningFilesTime + findPreviewsTime} ms")
+            appendLine("==============================================================")
+            appendLine()
+        }
+        println(logBuilder.toString())
     }
 }

--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/logger/ScanResultLogger.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/scanresult/logger/ScanResultLogger.kt
@@ -55,23 +55,29 @@ internal class ScanResultLogger {
 
     fun printFullInfoLog() {
         if (!isLoggingEnabled) return
+        val logBuilder = StringBuilder()
 
-        println("==============================================================")
-        println("Scan Result Dumper")
-        println("==============================================================")
-        println(scanningSource)
+        logBuilder.run {
+            appendLine("==============================================================")
+            appendLine("Scan Result Dumper")
+            appendLine("==============================================================")
+            appendLine(scanningSource)
+        }
         classpath?.run {
-            println("Source set (compiled classes path): $rootDir/$packagePath")
+            logBuilder.appendLine("Source set (compiled classes path): $rootDir/$packagePath")
         }
         scanResultFileName?.run {
-            println("File to dump Scan Result: $this")
+            logBuilder.appendLine("File to dump Scan Result: $this")
         }
         customPreviewsFileName?.run {
-            println("File to dump Custom Previews: $this")
+            logBuilder.appendLine("File to dump Custom Previews: $this")
         }
-        println()
-        println("Time to dump scan result: $dumpScanResultTime ms")
-        println("==============================================================")
-        println()
+        logBuilder.run {
+            appendLine()
+            appendLine("Time to dump scan result: $dumpScanResultTime ms")
+            appendLine("==============================================================")
+            appendLine()
+        }
+        println(logBuilder.toString())
     }
 }


### PR DESCRIPTION
Updated PreviewScanningLogger and ScanResultLogger to build log output using StringBuilder before printing. This change improves log formatting and performance by reducing multiple println calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized logging efficiency in the scanning and result modules through streamlined output operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->