### PR TITLE
Deprecate public apis in :common and :jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ JVM-based (i.e. Paparazzi, Roborazzi) as well as Instrumentation-based (i.e. Sho
 > [!NOTE]
 > 1. Support for Wear OS Tile `@Previews` is under evaluation</br>
 > 2. `common` and `desktop` previews are deprecated in favour of the `android` preview (`androidx.compose.ui.tooling.preview.Preview`), which can be used
-> in `common` and JVM-based source sets like `desktop` since Compose Multiplatform 1.10.0-beta-02</br>
+> in `common` and JVM-based source sets like `desktop` since Compose Multiplatform 1.10.0-beta-02. This library has also deprecated its support. More info in [README_DEPRECATED.md](README_DEPRECATED.md)</br>
 
 
 #### Provide anonymous feedback
@@ -43,7 +43,7 @@ Help shape its future by taking [this quick survey](https://forms.gle/jcvggBxv14
 <sup>3</sup> Showkase components only hold information about the Composable, but not about the Preview Info (i.e. ApiLevel, Locale, UiMode, FontScale...).</br></br>
 <sup>4</sup> ComposablePreviewScanner supports adding extra lib-config (e.g. Paparazzi's Rendering Mode or Roborazzi's compare options) in the form of annotations that are additionally added to the preview. You can check how in the examples below in [Jvm Screenshot Tests](#jvm-screenshot-tests) and [Instrumentation Screenshot Tests](#instrumentation-screenshot-tests) respectively.</br></br>
 <sup>5</sup> Compose Preview Screenshot Testing supports *only general tolerance* via gradle plugin from version [0.0.1-alpha06](https://developer.android.com/studio/preview/compose-screenshot-testing#001-alpha06)</br></br>
-<sup>6</sup> Desktop Previews (which are deprecated since Compose Multiplatform 1.10.0-beta02) are supported with a workaround</br></br>
+<sup>6</sup> Desktop Previews (which are deprecated since Compose Multiplatform 1.10.0-beta02) are supported with a workaround. See [README_DEPRECATED.md](README_DEPRECATED.md)</br></br>
 <sup>7</sup> [Showkase: Compose Multiplatform Support](https://github.com/airbnb/Showkase/issues/364)
 </br></br></br>
 ComposablePreviewScanner also works with:
@@ -74,11 +74,11 @@ dependencies {
     // supported since 0.7.0+ in android target
     testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:glance:<version>")
     
-    // common previews (org.jetbrains.compose.ui.tooling.preview.Preview)
+    // common previews (org.jetbrains.compose.ui.tooling.preview.Preview) (deprecated)
     // supported in jvm targets e.g. android & desktop
     testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:common:<version>")
 
-    // desktop previews (androidx.compose.desktop.ui.tooling.preview.Preview) via custom annotation
+    // desktop previews (androidx.compose.desktop.ui.tooling.preview.Preview) via custom annotation (deprecated)
     // supported in jvm targets e.g. android & desktop
     testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:jvm:<version>")
 }
@@ -104,11 +104,11 @@ dependencies {
     // supported since 0.7.0+ in android target
     testImplementation("com.github.sergio-sastre.ComposablePreviewScanner:glance:<version>")
 
-    // common previews (org.jetbrains.compose.ui.tooling.preview.Preview)
+    // common previews (org.jetbrains.compose.ui.tooling.preview.Preview) (deprecated)
     // supported in jvm targets e.g. android & desktop
     testImplementation("com.github.sergio-sastre.ComposablePreviewScanner:common:<version>")
 
-    // desktop previews (androidx.compose.desktop.ui.tooling.preview.Preview) via custom annotation
+    // desktop previews (androidx.compose.desktop.ui.tooling.preview.Preview) via custom annotation (deprecated)
     // supported in jvm targets e.g. android & desktop
     testImplementation("com.github.sergio-sastre.ComposablePreviewScanner:jvm:<version>")
 }
@@ -131,7 +131,7 @@ If you encounter any issues when executing the screenshot tests, take a look at 
 2. [Compose Multiplatform Support](#compose-multiplatform-support)
 
 ## API   
-`AndroidComposablePreviewScanner`, `GlanceComposablePreviewScanner`, `CommonComposablePreviewScanner`, and `JvmAnnotationScanner` have the same API.
+`AndroidComposablePreviewScanner`, `GlanceComposablePreviewScanner`, `CommonComposablePreviewScanner` (deprecated), and `JvmAnnotationScanner` (deprecated) have the same API.
 The API is pretty simple:
 
 ```kotlin
@@ -922,102 +922,7 @@ You can find executable examples with Roborazzi here:
 - [Android @Previews in common](https://github.com/sergio-sastre/roborazzi/blob/droidcon/preview_tests/sample-generate-preview-common/src/androidUnitTest/kotlin/com/github/takahirom/preview/tests/AndroidPreviewTest.kt)
 - [Android @Previews in desktop](https://github.com/sergio-sastre/roborazzi/blob/droidcon/preview_tests/sample-generate-preview-desktop/src/desktopTest/kotlin/AndroidPreviewTest.kt)
 
-If you are still using the deprecated Common or Desktop `@Preview` annotations, see the sections below for guidance.
-
-### Common Previews
-You can find executable examples here:
-- [Roborazzi](https://github.com/sergio-sastre/roborazzi/blob/droidcon/preview_tests/sample-generate-preview-common/src/androidUnitTest/kotlin/com/github/takahirom/preview/tests/CommonPreviewTest.kt)
-- [Paparazzi](https://github.com/sergio-sastre/ComposablePreviewScanner/blob/master/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/paparazzi/PaparazziCommonComposablePreviewInvokeTests.kt)
-
-And also [a video on how to set it with Roborazzi here](https://www.youtube.com/watch?v=zYsNXrf2-Lo&t=33m29s), and the [repo used in the video here](https://github.com/sergio-sastre/roborazzi/tree/droidcon/preview_tests).
-
-Executable examples with Instrumentation-based screenshot testing libraries are coming soon.</br></br>
-
-Since Compose Multiplatform 1.6.0, JetBrains has added support for `@Preview`s in `common`. ComposablePreviewScanner can also
-scan such Previews when running on any jvm-target, like
-- Android
-- Desktop
-- Jvm
-
-ComposablePreviewScanner provides a `CommonComposablePreviewScanner` for that purpose.
-
-Assuming that you have:
-- some Compose Multiplatform `@Previews` defined in `common`
-- some jvm-target module (i.e. Android or Desktop) where you want to run screenshot tests for those `@Previews`. That's because ComposablePreviewScanner only works in jvm-targets for now.
-
-Here is how you could also run screenshot tests for those Compose Multiplatform `@Previews` together, for instance, with Roborazzi (would also work with Paparazzi or any Instrumentation-based library).
-
-1. Add `:common` dependency for ComposablePreviewScanner e.g. `io.github.sergio-sastre.ComposablePreviewScanner:common:<version>`.
-2. Add an additional Parameterized screenshot test for these Compose Multiplatform `@Previews`. This is basically the same as in the corresponding [Paparazzi](#paparazzi), [Roborazzi](#roborazzi), or [Instrumentation screenshot tests](#instrumentation-screenshot-tests) sections, but use `CommonComposablePreviewScanner<CommonPreviewInfo>` and `CommonPreviewScreenshotIdBuilder`.
-3. Run these screenshot tests by executing the corresponding command e.g. for android: `./gradlew yourModule:recordRoborazziDebug`
-
-### Desktop Previews
-You can find [a video on how to set it with Roborazzi here](https://www.youtube.com/watch?v=zYsNXrf2-Lo&t=23m52s), and the [repo used in the video here](https://github.com/sergio-sastre/roborazzi/tree/droidcon/preview_tests).
-
-As we've seen in the previous section [How it works](#how-it-works), Compose-Desktop previews are still not visible to ClassGraph since they use `AnnotationRetention.SOURCE`.
-There is [already an open issue](https://youtrack.jetbrains.com/issue/CMP-5675) to change it to `AnnotationRetention.BINARY`, which would allow ClassGraph to find them.
-
-In the meanwhile, it is also possible to workaround this limitation with ComposablePreviewScanner as follows.
-
-1. Add `:jvm` dependency from ComposablePreviewScanner 0.2.0+ and use Roborazzi, since it is the only Screenshot Testing Library that supports Compose-Desktop
-   `testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:jvm:<version>")`
-
-2. Configure Roborazzi as described [in the corresponding "Multiplatform support" section](https://github.com/takahirom/roborazzi?tab=readme-ov-file#multiplatform-support)
-
-3. Define your own annotation. The only condition is not to define `AnnotationRetention.SOURCE`
-   ```kotlin
-   package my.package.path
-      
-   @Target(AnnotationTarget.FUNCTION)
-   annotation class DesktopScreenshot
-   ```
-4. Annotate the Desktop Composables you want to generate screenshot tests for with this annotation, e.g.
-```kotlin
-    @DesktopScreenshot
-    @Preview // It'd also work without this annotation
-    @Composable
-    fun MyDesktopComposable() { 
-        // Composable code here
-    }
-```
-
-5. Create the parameter provider for the Parameterized test. We can use [TestParameterInjector](https://github.com/google/TestParameterInjector) for that
-```kotlin
-class DesktopPreviewProvider : TestParameterValuesProvider() {
-  @OptIn(RequiresShowStandardStreams::class)
-  override fun provideValues(context: Context?): List<ComposablePreview<JvmAnnotationInfo>> =
-    JvmAnnotationScanner("my.package.path.DesktopScreenshot")
-      .enableScanningLogs()
-      .scanPackageTrees("previews")
-      .getPreviews()
-}
-```
-
-6. Write the Parameterized test itself
-```kotlin
-fun screenshotNameFor(preview: ComposablePreview<JvmAnnotationInfo>): String =
-   "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/${preview.declaringClass}.${preview.methodName}.png"
-
-@RunWith(TestParameterInjector::class)
-class DesktopPreviewTest(
-   @TestParameter(valuesProvider = DesktopPreviewProvider::class)
-   val preview: ComposablePreview<JvmAnnotationInfo>
-) {
-   @OptIn(ExperimentalTestApi::class)
-   @Test
-   fun test() {
-      ROBORAZZI_DEBUG = true
-      runDesktopComposeUiTest {
-         setContent { preview() }
-         onRoot().captureRoboImage(
-            filePath = screenshotNameFor(preview),
-         )
-      }
-   }
-}
-```
-
-7. Run these Roborazzi tests by executing the corresponding command e.g. `./gradlew yourModule:recordRoborazziJvm` (if using the Kotlin Jvm Plugin)
+If you are still using the deprecated Common or Desktop `@Preview` annotations, see [README_DEPRECATED.md](README_DEPRECATED.md) for guidance.
 
 # Resources 
 ## Tech talks

--- a/README_DEPRECATED.md
+++ b/README_DEPRECATED.md
@@ -1,0 +1,101 @@
+# Deprecated Modules
+
+> [!WARNING]
+> The `:common` and `:jvm` modules are deprecated and will be removed in version 0.10.0.
+> Starting with Compose Multiplatform 1.10.0-beta02, Common and Desktop `@Preview` annotations are deprecated in favour of the Android `@Preview` annotation (`androidx.compose.ui.tooling.preview.Preview`), which can be used across `common` and `desktop` platforms as well.
+> After migrating to these Android `@Preview`s, please migrate to using `AndroidComposablePreviewScanner` as described in the main [README.md](README.md).
+
+### Common Previews (Deprecated)
+You can find executable examples here:
+- [Roborazzi](https://github.com/sergio-sastre/roborazzi/blob/droidcon/preview_tests/sample-generate-preview-common/src/androidUnitTest/kotlin/com/github/takahirom/preview/tests/CommonPreviewTest.kt)
+- [Paparazzi](https://github.com/sergio-sastre/ComposablePreviewScanner/blob/master/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/paparazzi/PaparazziCommonComposablePreviewInvokeTests.kt)
+
+And also [a video on how to set it with Roborazzi here](https://www.youtube.com/watch?v=zYsNXrf2-Lo&t=33m29s), and the [repo used in the video here](https://github.com/sergio-sastre/roborazzi/tree/droidcon/preview_tests).
+
+Executable examples with Instrumentation-based screenshot testing libraries are coming soon.</br></br>
+
+Since Compose Multiplatform 1.6.0, JetBrains has added support for `@Preview`s in `common`. ComposablePreviewScanner can also
+scan such Previews when running on any jvm-target, like
+- Android
+- Desktop
+- Jvm
+
+ComposablePreviewScanner provides a `CommonComposablePreviewScanner` for that purpose.
+
+Assuming that you have:
+- some Compose Multiplatform `@Previews` defined in `common`
+- some jvm-target module (i.e. Android or Desktop) where you want to run screenshot tests for those `@Previews`. That's because ComposablePreviewScanner only works in jvm-targets for now.
+
+Here is how you could also run screenshot tests for those Compose Multiplatform `@Previews` together, for instance, with Roborazzi (would also work with Paparazzi or any Instrumentation-based library).
+
+1. Add `:common` dependency for ComposablePreviewScanner e.g. `io.github.sergio-sastre.ComposablePreviewScanner:common:<version>`.
+2. Add an additional Parameterized screenshot test for these Compose Multiplatform `@Previews`. This is basically the same as in the corresponding [Paparazzi](README.md#paparazzi), [Roborazzi](README.md#roborazzi), or [Instrumentation screenshot tests](README.md#instrumentation-screenshot-tests) sections, but use `CommonComposablePreviewScanner<CommonPreviewInfo>` and `CommonPreviewScreenshotIdBuilder`.
+3. Run these screenshot tests by executing the corresponding command e.g. for android: `./gradlew yourModule:recordRoborazziDebug`
+
+### Desktop Previews (Deprecated)
+You can find [a video on how to set it with Roborazzi here](https://www.youtube.com/watch?v=zYsNXrf2-Lo&t=23m52s), and the [repo used in the video here](https://github.com/sergio-sastre/roborazzi/tree/droidcon/preview_tests).
+
+As we've seen in the previous section [How it works](README.md#how-it-works), Compose-Desktop previews are still not visible to ClassGraph since they use `AnnotationRetention.SOURCE`.
+There is [already an open issue](https://youtrack.jetbrains.com/issue/CMP-5675) to change it to `AnnotationRetention.BINARY`, which would allow ClassGraph to find them.
+
+In the meanwhile, it is also possible to workaround this limitation with ComposablePreviewScanner as follows.
+
+1. Add `:jvm` dependency from ComposablePreviewScanner 0.2.0+ and use Roborazzi, since it is the only Screenshot Testing Library that supports Compose-Desktop
+   `testImplementation("io.github.sergio-sastre.ComposablePreviewScanner:jvm:<version>")`
+
+2. Configure Roborazzi as described [in the corresponding "Multiplatform support" section](https://github.com/takahirom/roborazzi?tab=readme-ov-file#multiplatform-support)
+
+3. Define your own annotation. The only condition is not to define `AnnotationRetention.SOURCE`
+   ```kotlin
+   package my.package.path
+      
+   @Target(AnnotationTarget.FUNCTION)
+   annotation class DesktopScreenshot
+   ```
+4. Annotate the Desktop Composables you want to generate screenshot tests for with this annotation, e.g.
+```kotlin
+    @DesktopScreenshot
+    @Preview // It'd also work without this annotation
+    @Composable
+    fun MyDesktopComposable() { 
+        // Composable code here
+    }
+```
+
+5. Create the parameter provider for the Parameterized test. We can use [TestParameterInjector](https://github.com/google/TestParameterInjector) for that
+```kotlin
+class DesktopPreviewProvider : TestParameterValuesProvider() {
+  @OptIn(RequiresShowStandardStreams::class)
+  override fun provideValues(context: Context?): List<ComposablePreview<JvmAnnotationInfo>> =
+    JvmAnnotationScanner("my.package.path.DesktopScreenshot")
+      .enableScanningLogs()
+      .scanPackageTrees("previews")
+      .getPreviews()
+}
+```
+
+6. Write the Parameterized test itself
+```kotlin
+fun screenshotNameFor(preview: ComposablePreview<JvmAnnotationInfo>): String =
+   "$DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH/${preview.declaringClass}.${preview.methodName}.png"
+
+@RunWith(TestParameterInjector::class)
+class DesktopPreviewTest(
+   @TestParameter(valuesProvider = DesktopPreviewProvider::class)
+   val preview: ComposablePreview<JvmAnnotationInfo>
+) {
+   @OptIn(ExperimentalTestApi::class)
+   @Test
+   fun test() {
+      ROBORAZZI_DEBUG = true
+      runDesktopComposeUiTest {
+         setContent { preview() }
+         onRoot().captureRoboImage(
+            filePath = screenshotNameFor(preview),
+         )
+      }
+   }
+}
+```
+
+7. Run these Roborazzi tests by executing the corresponding command e.g. `./gradlew yourModule:recordRoborazziJvm` (if using the Kotlin Jvm Plugin)

--- a/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonComposablePreviewScanner.kt
+++ b/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonComposablePreviewScanner.kt
@@ -20,6 +20,9 @@ import java.lang.reflect.Method
  * WARNING: Since ComposablePreviewScanner is based on ClassGraph, which is a Jvm-based Class Scanner,
  * this can only be used inside jvm sources, like Desktop and Android.
  */
+@Deprecated(
+    message = "The :common module is deprecated and will be removed in 0.10.0. Use Android Previews instead.",
+)
 class CommonComposablePreviewScanner : ComposablePreviewScanner<CommonPreviewInfo>(
     findComposableWithPreviewsInClass = CommonComposablePreviewFinder()
 ) {

--- a/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonPreviewInfo.kt
+++ b/common/src/main/java/sergio/sastre/composable/preview/scanner/common/CommonPreviewInfo.kt
@@ -1,5 +1,8 @@
 package sergio.sastre.composable.preview.scanner.common
 
+@Deprecated(
+    message = "The :common module is deprecated and will be removed in 0.10.0. Use Android Previews instead.",
+)
 data class CommonPreviewInfo(
     val name: String = "",
     val group: String = "",

--- a/common/src/main/java/sergio/sastre/composable/preview/scanner/common/screenshotid/CommonPreviewScreenshotIdBuilder.kt
+++ b/common/src/main/java/sergio/sastre/composable/preview/scanner/common/screenshotid/CommonPreviewScreenshotIdBuilder.kt
@@ -5,6 +5,9 @@ import sergio.sastre.composable.preview.scanner.core.preview.screenshotid.Defaul
 import sergio.sastre.composable.preview.scanner.core.preview.screenshotid.PreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.common.CommonPreviewInfo
 
+@Deprecated(
+    message = "The :common module is deprecated and will be removed in 0.10.0. Use Android Previews instead.",
+)
 class CommonPreviewScreenshotIdBuilder(
     private val composablePreview: ComposablePreview<CommonPreviewInfo>
 ): PreviewScreenshotIdBuilder<CommonPreviewInfo>(

--- a/jvm/src/main/java/sergio/sastre/composable/preview/scanner/jvm/JvmAnnotationInfo.kt
+++ b/jvm/src/main/java/sergio/sastre/composable/preview/scanner/jvm/JvmAnnotationInfo.kt
@@ -1,3 +1,6 @@
 package sergio.sastre.composable.preview.scanner.jvm
 
+@Deprecated(
+    message = "The :jvm module is deprecated and will be removed in 0.10.0. Use Android Previews instead.",
+)
 data object JvmAnnotationInfo

--- a/jvm/src/main/java/sergio/sastre/composable/preview/scanner/jvm/JvmAnnotationScanner.kt
+++ b/jvm/src/main/java/sergio/sastre/composable/preview/scanner/jvm/JvmAnnotationScanner.kt
@@ -19,6 +19,9 @@ import java.lang.reflect.Method
  * like androidx.compose.desktop.ui.tooling.preview.Preview, and therefore it cannot be found by ClassGraph.
  * In such case, that @preview can be extra annotated with a custom annotation -> annotationToScanClassName
  */
+@Deprecated(
+    message = "The :jvm module is deprecated and will be removed in 0.10.0. Use Android Previews instead.",
+)
 class JvmAnnotationScanner(
     annotationToScanClassName: String
 ) : ComposablePreviewScanner<JvmAnnotationInfo>(

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanner/CommonComposablePreviewScannerTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanner/CommonComposablePreviewScannerTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import sergio.sastre.composable.preview.scanner.CommonStringProvider
 import sergio.sastre.composable.preview.scanner.common.CommonComposablePreviewScanner
 
+@Suppress("DEPRECATION")
 class CommonComposablePreviewScannerTest {
 
     @Test

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanner/JvmAnnotationScannerTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanner/JvmAnnotationScannerTest.kt
@@ -3,6 +3,7 @@ package sergio.sastre.composable.preview.scanner.tests.api.main.scanner
 import org.junit.Test
 import sergio.sastre.composable.preview.scanner.jvm.JvmAnnotationScanner
 
+@Suppress("DEPRECATION")
 class JvmAnnotationScannerTest {
 
     @Test

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanninglogger/ComposablePreviewScanningLoggerTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/scanninglogger/ComposablePreviewScanningLoggerTest.kt
@@ -16,6 +16,7 @@ import sergio.sastre.composable.preview.scanner.glance.GlanceComposablePreviewSc
 import sergio.sastre.composable.preview.scanner.common.CommonComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.utils.SystemOutputTestRule
 
+@Suppress("DEPRECATION")
 @RunWith(Parameterized::class)
 class ComposablePreviewScanningLoggerTest<T>(
     // New Scanner instance on each test

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/screenshotid/CommonComposablePreviewScreenshotIdTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/screenshotid/CommonComposablePreviewScreenshotIdTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package sergio.sastre.composable.preview.scanner.tests.api.main.screenshotid
 
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -9,6 +10,7 @@ import sergio.sastre.composable.preview.scanner.common.CommonPreviewInfo
 import sergio.sastre.composable.preview.scanner.common.screenshotid.CommonPreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.utils.previewBuilder
 
+@Suppress("DEPRECATION")
 @RunWith(TestParameterInjector::class)
 class CommonComposablePreviewScreenshotIdTest {
 

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/screenshotid/ComposablePreviewToStringTest.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/api/main/screenshotid/ComposablePreviewToStringTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.common.CommonComposablePreviewScanner
 
+@Suppress("DEPRECATION")
 class ComposablePreviewToStringTest() {
 
     @Test

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/paparazzi/runtime/PaparazziCommonComposablePreviewInvokeTests.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/paparazzi/runtime/PaparazziCommonComposablePreviewInvokeTests.kt
@@ -31,6 +31,7 @@ import kotlin.math.ceil
  *
  * ./gradlew :tests:recordPaparazziDebug --tests 'PaparazziCommonComposablePreviewInvokeTests' -Plibrary=paparazzi
  */
+@Suppress("DEPRECATION")
 @RunWith(Parameterized::class)
 class PaparazziCommonComposablePreviewInvokeTests(
     private val preview: ComposablePreview<CommonPreviewInfo>,

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/roborazzi/runtime/CommonComposablePreviewInvokeExpectedErrorTests.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/roborazzi/runtime/CommonComposablePreviewInvokeExpectedErrorTests.kt
@@ -19,6 +19,7 @@ import sergio.sastre.composable.preview.scanner.common.screenshotid.CommonPrevie
  *
  * ./gradlew :tests:recordRoborazziDebug --tests 'CommonComposablePreviewInvokeExpectedErrorTests' -Plibrary=roborazzi
  */
+@Suppress("DEPRECATION")
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class CommonComposablePreviewInvokeExpectedErrorTests(
     private val preview: ComposablePreview<CommonPreviewInfo>,

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/roborazzi/runtime/RoborazziCommonComposablePreviewInvokeTests.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/tests/roborazzi/runtime/RoborazziCommonComposablePreviewInvokeTests.kt
@@ -23,6 +23,7 @@ import sergio.sastre.composable.preview.scanner.common.screenshotid.CommonPrevie
  *
  * ./gradlew :tests:recordRoborazziDebug --tests 'RoborazziCommonComposablePreviewInvokeTests' -Plibrary=roborazzi
  */
+@Suppress("DEPRECATION")
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class RoborazziCommonComposablePreviewInvokeTests(
     private val preview: ComposablePreview<CommonPreviewInfo>,

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/utils/PreviewBuilder.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/utils/PreviewBuilder.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package sergio.sastre.composable.preview.scanner.utils
 
 import androidx.compose.runtime.Composable

--- a/tests/src/test/java/sergio/sastre/composable/preview/scanner/utils/PreviewScreenshotIdBuilderProvider.kt
+++ b/tests/src/test/java/sergio/sastre/composable/preview/scanner/utils/PreviewScreenshotIdBuilderProvider.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package sergio.sastre.composable.preview.scanner.utils
 
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Multiple classes in the `:common` and `:jvm` modules are now marked as deprecated and scheduled for removal in version 0.10.0. Users are encouraged to migrate to Android Previews for composable preview functionality.
  * Added deprecation warning suppressions across test files to allow testing of deprecated components without triggering compiler warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->