### PR TITLE
Bugfix/#138 resolve ambiguity with wrap method in preview wrapper

### DIFF
--- a/core/src/main/java/sergio/sastre/composable/preview/scanner/core/preview/ComposablePreview.kt
+++ b/core/src/main/java/sergio/sastre/composable/preview/scanner/core/preview/ComposablePreview.kt
@@ -107,7 +107,12 @@ internal object PreviewWrapperCache {
                 .newInstance()
             // Find Wrap(Function2, Composer, Int)
             val wrapMethod = clazz.declaredMethods
-                .find { it.name == "Wrap" }
+                .find { method ->
+                    method.name == "Wrap" &&
+                            method.parameterCount == 3 &&
+                            method.parameterTypes[0].name == "kotlin.jvm.functions.Function2" &&
+                            method.parameterTypes[1].name == "androidx.compose.runtime.Composer"
+                }
                 ?.apply { isAccessible = true }
             val newPair = instance to wrapMethod
             val existing = cache.putIfAbsent(className, newPair)

--- a/tests/src/main/java/sergio/sastre/composable/preview/scanner/android/previewwrapper/Composables.kt
+++ b/tests/src/main/java/sergio/sastre/composable/preview/scanner/android/previewwrapper/Composables.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,10 +16,6 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 
 private class PrivateScaffoldWrapper : PreviewWrapperProvider {
-    @Composable
-    fun Wrap(color: Color, string: String, content: @Composable () -> Unit){
-        // no-op Use this to ensure we pick the other method via reflection
-    }
 
     @Composable
     override fun Wrap(content: @Composable () -> Unit) {
@@ -34,8 +31,22 @@ private class PrivateScaffoldWrapper : PreviewWrapperProvider {
 
 class PublicScaffoldWrapper: PreviewWrapperProvider {
     @Composable
-    fun Wrap(color: Color, string: String, content: @Composable () -> Unit){
+    fun Wrap(content: @Composable () -> Unit, misleadingArg: Int){
         // no-op Use this to ensure we pick the other method via reflection
+        throw RuntimeException("WRONG - Too many params")
+    }
+
+    @Composable
+    fun Wrap(content: () -> Unit){
+        // no-op Use this to ensure we pick the other method via reflection
+        throw RuntimeException("WRONG - Non-Composable Unit param")
+    }
+
+    @Composable
+    fun Wrap(content: (Composer, Int) -> Unit, composer: Composer, changed: Int) {
+        // Bytecode: (Function2, Composer, int)
+        // This is IDENTICAL to the overridden Wrap in terms of reflection types!
+        throw RuntimeException("WRONG - This is not @Composable but looks like it")
     }
 
     @Composable

--- a/tests/src/main/java/sergio/sastre/composable/preview/scanner/android/previewwrapper/Composables.kt
+++ b/tests/src/main/java/sergio/sastre/composable/preview/scanner/android/previewwrapper/Composables.kt
@@ -46,7 +46,7 @@ class PublicScaffoldWrapper: PreviewWrapperProvider {
     fun Wrap(content: (Composer, Int) -> Unit, composer: Composer, changed: Int) {
         // Bytecode: (Function2, Composer, int)
         // This is IDENTICAL to the overridden Wrap in terms of reflection types!
-        throw RuntimeException("WRONG - This is not @Composable but looks like it")
+        throw RuntimeException("WRONG - This is not @Composable and looks identical reflection-wise")
     }
 
     @Composable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview wrapper detection to select only compatible `Wrap` methods.
  * Prevented incorrect overloads from being selected during preview scanning.
* **Tests**
  * Expanded test coverage for overloaded and incompatible wrapper methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->